### PR TITLE
feat: mobile 页支持 wss，适配 HTTPS 反向代理

### DIFF
--- a/phonemic/resources/mobile.html
+++ b/phonemic/resources/mobile.html
@@ -917,7 +917,8 @@
         const chatManager = new ChatListManager(chatContainer, appConfig);
         window.chatManagerInstance = chatManager;
 
-        const wsClient = new WSClient(`ws://${window.location.host}/ws`, appConfig);
+        const wsProto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+        const wsClient = new WSClient(`${wsProto}//${location.host}/ws`, appConfig);
         const uiController = new UIController(inputBox, btnSend, btnClear, modeToggle, chatManager, wsClient, appConfig);
         
         new MessageInteractionManager(chatContainer, uiController, wsClient);


### PR DESCRIPTION
非常感谢作者提供的这个小工具，这里做了一个优化，可以让移动端页面根据协议选择使用ws还是wss。

原因是手机和电脑无法在同一个内网条件，于是用nginx反向代理，让手机访问外网的域名来连接的工具，已经顺利用上了🎈。
感觉可能有其他人可能也会用外网域名连接，在https下就需要使用wss，简单优化了一下